### PR TITLE
Enhance SEO component with new preview image and Open Graph metadata

### DIFF
--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -1,6 +1,5 @@
 ---
 import { getLangFromUrl } from '@i18n/utils';
-import { ui, defaultLang } from '../i18n/ui';
 interface Props{
     title: string;
     description: string;
@@ -23,23 +22,32 @@ const {
 
 const siteName = 'Kevin Arauz';
 const fullTitle = `${title} | ${siteName}`;
-const absoluteImage = new URL(image, Astro.site).href;
+const baseUrl = Astro.site ?? Astro.url.origin;
+const absoluteCanonicalUrl = new URL(canonicalURL, baseUrl).href;
+const absoluteImage = new URL(image, baseUrl).href;
 const lang = getLangFromUrl(Astro.url);
+const ogLocale = lang === 'en' ? 'en_US' : 'es_ES';
 
 ---
 
 <title>{fullTitle}</title>
 <meta name="description" content={description} />
 <meta name="author" content={author} />
-<link rel="canonical" href={canonicalURL} />
+<meta name="robots" content="index,follow" />
+<link rel="canonical" href={absoluteCanonicalUrl} />
 
 <!-- Open Graph -->
 <meta property="og:type" content={type} />
 <meta property="og:title" content={fullTitle} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={absoluteImage} />
-<meta property="og:url" content={canonicalURL} />
+<meta property="og:image:secure_url" content={absoluteImage} />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content={fullTitle} />
+<meta property="og:url" content={absoluteCanonicalUrl} />
 <meta property="og:site_name" content={siteName} />
+<meta property="og:locale" content={ogLocale} />
 
 
 <!-- Twitter Card -->
@@ -47,6 +55,8 @@ const lang = getLangFromUrl(Astro.url);
 <meta name="twitter:title" content={fullTitle} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={absoluteImage} />
+<meta name="twitter:url" content={absoluteCanonicalUrl} />
+<meta name="twitter:image:alt" content={fullTitle} />
 
 <!-- Blog post específico -->
 {publishedDate && <meta property="article:published_time" content={publishedDate} />}

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -43,7 +43,7 @@ const blogIndexHref = langSegment ? `/${langSegment}/blog` : '/blog';
     <SEO
       title={post.title}
       description={post.description}
-      image={post.coverImage ?? "/og-default.png"}
+      image={post.coverImage ?? "/preview.png"}
       type="article"
       publishedDate={post.publishedAt?.toISOString()}
     />
@@ -56,7 +56,7 @@ const blogIndexHref = langSegment ? `/${langSegment}/blog` : '/blog';
         "@type": "BlogPosting",
         headline: post.title,
         description: post.description,
-        image: new URL(post.coverImage ?? "/og-default.png", Astro.site).href,
+        image: new URL(post.coverImage ?? "/preview.png", Astro.site).href,
         author: {
           "@type": "Person",
           name: "Tu Nombre",


### PR DESCRIPTION
This pull request updates the SEO component and blog post layout to improve metadata handling, canonical URLs, and image defaults. The changes enhance Open Graph and Twitter card support, ensure URLs are always absolute, and update the default preview image.

**SEO and Metadata Improvements:**

* The `SEO.astro` component now generates absolute canonical URLs and image URLs using a more robust base URL fallback, ensuring correctness even if `Astro.site` is undefined. It also adds Open Graph image metadata (secure URL, width, height, alt text) and locale, and includes a `robots` meta tag. Twitter metadata is expanded to include image alt text and canonical URL.

**Image Handling Updates:**

* The default preview image for blog posts is changed from `/og-default.png` to `/preview.png` in both the `SEO` component usage and the blog post structured data, ensuring consistency in image previews. [[1]](diffhunk://#diff-ce25bc7c3179935e67a17aea1a0d4212ea35bc8cdaa4f005a2c7999b4cbf46a7L46-R46) [[2]](diffhunk://#diff-ce25bc7c3179935e67a17aea1a0d4212ea35bc8cdaa4f005a2c7999b4cbf46a7L59-R59)

**Code Cleanup:**

* Removed an unused import (`ui`, `defaultLang`) from `SEO.astro` for cleaner code.…Graph metadata