### PR TITLE
Streamline authentication logic and user session handling

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,18 +14,19 @@ export const onRequest = defineMiddleware(async (context, next) => {
     return context.redirect(`/${lang}/`);
   }
 
-  const isAuthed = await auth.api
-        .getSession({
-            headers: context.request.headers,
-        })
-    if (isAuthed) {
-        context.locals.user = isAuthed.user;
-        context.locals.session = isAuthed.session;
-    } else {
-        context.locals.user = null;
-        context.locals.session = null;
-    }
-
+  const isAuthed = await auth.api.getSession({
+    headers: context.request.headers,
+  });
+  if (isAuthed) {
+    context.locals.user = isAuthed.user;
+    context.locals.session = isAuthed.session;
+  } else {
+    context.locals.user = null;
+    context.locals.session = null;
+  }
+  if (context.url.pathname === "/dashboard" && !isAuthed) {
+    return context.redirect("/");
+  }
 
   return next();
 });

--- a/src/pages/[lang]/dashboard/index.astro
+++ b/src/pages/[lang]/dashboard/index.astro
@@ -13,6 +13,8 @@ if(!Astro.locals.session){
 }
 
 const user = Astro.locals.user;
+
+export const prerender = false;
 ---
 
 <h1>Bienvenido, {user?.name ?? "usuario"}</h1>


### PR DESCRIPTION
This pull request introduces an authentication check for the `/dashboard` route and disables prerendering for the dashboard page. The main goal is to ensure that only authenticated users can access the dashboard, and that the page is always rendered dynamically.

Authentication and access control:

* Added a check in the `middleware.ts` file to redirect unauthenticated users from `/dashboard` to the home page (`/`).

Rendering behavior:

* Disabled prerendering for the dashboard page by setting `export const prerender = false` in `dashboard/index.astro`, ensuring dynamic rendering based on user authentication. ([src/pages/[lang]/dashboard/index.astroR16-R17](diffhunk://#diff-721040e1aa133c1cf1ee134af769d364ce1157c7af863639dd7f5fab56dbc670R16-R17))…d ensure user session handling